### PR TITLE
feat: update DirectionsAvailable model to use boolean flags for movem…

### DIFF
--- a/game/client/src/typescript/models.gen.ts
+++ b/game/client/src/typescript/models.gen.ts
@@ -1,25 +1,20 @@
 import type { SchemaType as ISchemaType } from "@dojoengine/sdk";
-
 import {
     CairoCustomEnum,
     CairoOption,
     CairoOptionVariant,
     BigNumberish,
 } from "starknet";
-
 type WithFieldOrder<T> = T & { fieldOrder: string[] };
-
 // Type definition for `dojo_starter::models::DirectionsAvailable` struct
 export interface DirectionsAvailable {
     player: string;
     directions: Array<DirectionEnum>;
 }
-
 // Type definition for `dojo_starter::models::DirectionsAvailableValue` struct
 export interface DirectionsAvailableValue {
     directions: Array<DirectionEnum>;
 }
-
 // Type definition for `dojo_starter::models::Moves` struct
 export interface Moves {
     player: string;
@@ -27,42 +22,35 @@ export interface Moves {
     last_direction: CairoOption<DirectionEnum>;
     can_move: boolean;
 }
-
 // Type definition for `dojo_starter::models::MovesValue` struct
 export interface MovesValue {
     remaining: BigNumberish;
     last_direction: CairoOption<DirectionEnum>;
     can_move: boolean;
 }
-
 // Type definition for `dojo_starter::models::Position` struct
 export interface Position {
     player: string;
     vec: Vec2;
 }
-
 // Type definition for `dojo_starter::models::PositionValue` struct
 export interface PositionValue {
     vec: Vec2;
 }
-
 // Type definition for `dojo_starter::models::Vec2` struct
 export interface Vec2 {
     x: BigNumberish;
     y: BigNumberish;
 }
-
 // Type definition for `dojo_starter::systems::actions::actions::Moved` struct
 export interface Moved {
     player: string;
     direction: DirectionEnum;
 }
-
 // Type definition for `dojo_starter::systems::actions::actions::MovedValue` struct
 export interface MovedValue {
     direction: DirectionEnum;
 }
-
 // Type definition for `dojo_starter::models::Direction` enum
 export type Direction = {
     Left: string;
@@ -71,7 +59,6 @@ export type Direction = {
     Down: string;
 };
 export type DirectionEnum = CairoCustomEnum;
-
 export interface SchemaType extends ISchemaType {
     dojo_starter: {
         DirectionsAvailable: WithFieldOrder<DirectionsAvailable>;

--- a/game/client/src/typescript/models.gen.ts
+++ b/game/client/src/typescript/models.gen.ts
@@ -1,4 +1,5 @@
 import type { SchemaType as ISchemaType } from "@dojoengine/sdk";
+
 import {
     CairoCustomEnum,
     CairoOption,
@@ -11,16 +12,12 @@ type WithFieldOrder<T> = T & { fieldOrder: string[] };
 // Type definition for `dojo_starter::models::DirectionsAvailable` struct
 export interface DirectionsAvailable {
     player: string;
-    up: boolean;
-    down: boolean;
-    both: boolean;
+    directions: Array<DirectionEnum>;
 }
 
 // Type definition for `dojo_starter::models::DirectionsAvailableValue` struct
 export interface DirectionsAvailableValue {
-    up: boolean;
-    down: boolean;
-    both: boolean;
+    directions: Array<DirectionEnum>;
 }
 
 // Type definition for `dojo_starter::models::Moves` struct
@@ -88,21 +85,30 @@ export interface SchemaType extends ISchemaType {
         MovedValue: WithFieldOrder<MovedValue>;
     };
 }
-
 export const schema: SchemaType = {
     dojo_starter: {
         DirectionsAvailable: {
-            fieldOrder: ["player", "up", "down", "both"],
+            fieldOrder: ["player", "directions"],
             player: "",
-            up: false,
-            down: false,
-            both: false,
+            directions: [
+                new CairoCustomEnum({
+                    Left: "",
+                    Right: undefined,
+                    Up: undefined,
+                    Down: undefined,
+                }),
+            ],
         },
         DirectionsAvailableValue: {
-            fieldOrder: ["up", "down", "both"],
-            up: false,
-            down: false,
-            both: false,
+            fieldOrder: ["directions"],
+            directions: [
+                new CairoCustomEnum({
+                    Left: "",
+                    Right: undefined,
+                    Up: undefined,
+                    Down: undefined,
+                }),
+            ],
         },
         Moves: {
             fieldOrder: ["player", "remaining", "last_direction", "can_move"],
@@ -152,7 +158,6 @@ export const schema: SchemaType = {
         },
     },
 };
-
 export enum ModelsMapping {
     Direction = "dojo_starter-Direction",
     DirectionsAvailable = "dojo_starter-DirectionsAvailable",

--- a/game/client/src/typescript/models.gen.ts
+++ b/game/client/src/typescript/models.gen.ts
@@ -1,5 +1,4 @@
 import type { SchemaType as ISchemaType } from "@dojoengine/sdk";
-
 import {
     CairoCustomEnum,
     CairoOption,
@@ -12,12 +11,16 @@ type WithFieldOrder<T> = T & { fieldOrder: string[] };
 // Type definition for `dojo_starter::models::DirectionsAvailable` struct
 export interface DirectionsAvailable {
     player: string;
-    directions: Array<DirectionEnum>;
+    up: boolean;
+    down: boolean;
+    both: boolean;
 }
 
 // Type definition for `dojo_starter::models::DirectionsAvailableValue` struct
 export interface DirectionsAvailableValue {
-    directions: Array<DirectionEnum>;
+    up: boolean;
+    down: boolean;
+    both: boolean;
 }
 
 // Type definition for `dojo_starter::models::Moves` struct
@@ -85,30 +88,21 @@ export interface SchemaType extends ISchemaType {
         MovedValue: WithFieldOrder<MovedValue>;
     };
 }
+
 export const schema: SchemaType = {
     dojo_starter: {
         DirectionsAvailable: {
-            fieldOrder: ["player", "directions"],
+            fieldOrder: ["player", "up", "down", "both"],
             player: "",
-            directions: [
-                new CairoCustomEnum({
-                    Left: "",
-                    Right: undefined,
-                    Up: undefined,
-                    Down: undefined,
-                }),
-            ],
+            up: false,
+            down: false,
+            both: false,
         },
         DirectionsAvailableValue: {
-            fieldOrder: ["directions"],
-            directions: [
-                new CairoCustomEnum({
-                    Left: "",
-                    Right: undefined,
-                    Up: undefined,
-                    Down: undefined,
-                }),
-            ],
+            fieldOrder: ["up", "down", "both"],
+            up: false,
+            down: false,
+            both: false,
         },
         Moves: {
             fieldOrder: ["player", "remaining", "last_direction", "can_move"],
@@ -158,6 +152,7 @@ export const schema: SchemaType = {
         },
     },
 };
+
 export enum ModelsMapping {
     Direction = "dojo_starter-Direction",
     DirectionsAvailable = "dojo_starter-DirectionsAvailable",

--- a/game/dojo/src/models.cairo
+++ b/game/dojo/src/models.cairo
@@ -15,9 +15,10 @@ pub struct Moves {
 pub struct DirectionsAvailable {
     #[key]
     pub player: ContractAddress,
-    pub directions: Array<Direction>,
+    pub up: bool,
+    pub down: bool,
+    pub both: bool,
 }
-
 #[derive(Copy, Drop, Serde, Debug)]
 #[dojo::model]
 pub struct Position {

--- a/game/dojo/src/systems/actions.cairo
+++ b/game/dojo/src/systems/actions.cairo
@@ -30,67 +30,106 @@ pub mod actions {
         fn spawn(ref self: ContractState) {
             // Get the default world.
             let mut world = self.world_default();
-
+        
             // Get the address of the current caller, possibly the player's address.
             let player = get_caller_address();
-            // Retrieve the player's current position from the world.
-            let position: Position = world.read_model(player);
-
-            // Update the world state with the new data.
-
-            // 1. Move the player's position 10 units in both the x and y direction.
+        
+            // Initialize the player's position.
             let new_position = Position {
-                player, vec: Vec2 { x: position.vec.x + 10, y: position.vec.y + 10 },
+                player,
+                vec: Vec2 { x: 0, y: 0 },
             };
-
-            // Write the new position to the world.
             world.write_model(@new_position);
-
-            // 2. Set the player's remaining moves to 100.
+        
+            // Initialize the player's moves.
             let moves = Moves {
-                player, remaining: 100, last_direction: Option::None, can_move: true,
+                player,
+                remaining: 100,
+                last_direction: Option::None,
+                can_move: true,
             };
-
-            // Write the new moves to the world.
             world.write_model(@moves);
+        
+            // Initialize the player's movement directions.
+            self.initialize_directions(player, true, true, false);
         }
 
         // Implementation of the move function for the ContractState struct.
         fn move(ref self: ContractState, direction: Direction) {
-            // Get the address of the current caller, possibly the player's address.
-
             let mut world = self.world_default();
-
             let player = get_caller_address();
-
+        
             // Retrieve the player's current position and moves data from the world.
             let position: Position = world.read_model(player);
             let mut moves: Moves = world.read_model(player);
-            // if player hasn't spawn, read returns model default values. This leads to sub overflow
-            // afterwards.
-            // Plus it's generally considered as a good pratice to fast-return on matching
-            // conditions.
+        
+            // If the player can't move, return early.
             if !moves.can_move {
                 return;
             }
-
+        
             // Deduct one from the player's remaining moves.
             moves.remaining -= 1;
-
+        
             // Update the last direction the player moved in.
             moves.last_direction = Option::Some(direction);
-
+        
             // Calculate the player's next position based on the provided direction.
             let next = next_position(position, moves.last_direction);
-
+        
             // Write the new position to the world.
             world.write_model(@next);
-
+        
             // Write the new moves to the world.
             world.write_model(@moves);
-
+        
+            // Update movement directions based on the current move.
+            match direction {
+                Direction::Up => {
+                    // Example: Disable moving down after moving up.
+                    self.update_directions(player, true, false, false);
+                },
+                Direction::Down => {
+                    // Example: Disable moving up after moving down.
+                    self.update_directions(player, false, true, false);
+                },
+                Direction::Left | Direction::Right => {
+                    // Example: Enable both up and down after moving left or right.
+                    self.update_directions(player, true, true, true);
+                },
+            }
+        
             // Emit an event to the world to notify about the player's move.
             world.emit_event(@Moved { player, direction });
+        }
+
+        fn initialize_directions(ref self: ContractState, player: ContractAddress, up: bool, down: bool, both: bool) {
+            let mut world = self.world_default();
+    
+            let directions = DirectionsAvailable {
+                player,
+                up,
+                down,
+                both,
+            };
+    
+            // Write the new directions to the world.
+            world.write_model(@directions);
+        }
+
+        fn update_directions(ref self: ContractState, player: ContractAddress, up: bool, down: bool, both: bool) {
+            let mut world = self.world_default();
+    
+            // Retrieve the existing directions for the player.
+            let mut directions: DirectionsAvailable = world.read_model(player);
+    
+            // Update the directions.
+            directions.up = up;
+            directions.down = down;
+            directions.both = both;
+    
+            // Write the updated directions back to the world.
+            world.write_model(@directions);
         }
     }
 


### PR DESCRIPTION
…ent directions

# 📝 Pull Request Title
Add model for storing piece movement directions

## 🛠️ Issue
- Closes #17 

## 📖 Description
- Updated the  model `DirectionsAvailable` to store the movement directions for each piece on the board.
- The model includes the following attributes:
  - `player`(piece_id): The unique identifier for the piece.
  - `up`: Boolean indicating if the piece can move upward.
  - `down`: Boolean indicating if the piece can move downward.
  - `both`: Boolean indicating if the piece can move both up and down.
- Integrated the model into the `actions.cairo` file, adding functions to initialize and update movement directions.
- Updated the client-side schema and types to reflect the new model structure.

## ✅ Changes made
- Updated the `DirectionsAvailable` model in `models.cairo`.
- Added `initialize_directions` and `update_directions` functions in `actions.cairo`.
- Integrated `update_directions` into the `move` function to dynamically update movement rules based on player actions.
- Updated the client-side schema and types to align with the new model structure.

## 🖼️ Media (screenshots/videos)


## 📜 Additional Notes
- The `DirectionsAvailable` model is designed to be easily extendable for future directions or attributes.
- The `update_directions` function ensures that movement rules can be dynamically updated during gameplay.
- The client-side schema has been updated to reflect the new model structure, ensuring consistency between the backend and frontend.